### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   Deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Deploy with hook
       run: curl ${{ secrets.DEPLOY_HOOK }}
-    


### PR DESCRIPTION
Potential fix for [https://github.com/MarioKartWorldItalia/MKW-Italia-Bot/security/code-scanning/1](https://github.com/MarioKartWorldItalia/MKW-Italia-Bot/security/code-scanning/1)

To fix the issue, add a `permissions:` block to the job (under `Deploy:`) or to the root of the workflow, specifying the minimum required permissions. Since the job steps only involve calling an external deploy hook with no interaction with the repository, it is safest to set all permissions to `none`, but `contents: read` is usually a minimal default. Place the `permissions:` block as a sibling to `runs-on:` inside the `Deploy` job. No new imports, definitions, or methods are required; you need only insert:

```yaml
permissions:
  contents: read
```

as line 9, shifting subsequent lines down by one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
